### PR TITLE
削除したノートが再同期時に復活する問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Build plugin
         env:
           OBSIDIAN_LINE_API_URL: ${{ secrets.OBSIDIAN_LINE_API_URL }}
+          NODE_ENV: production
         run: pnpm --filter obsidian-plugin build
 
       - name: Create release

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ main.js
 # Environment files
 .env
 .env.*
+!.env.sample
 
 # IDE and editor files
 .vscode/
@@ -46,9 +47,6 @@ build/
 
 # Wrangler
 .wrangler/
-
-# Environment variables
-.dev.vars
 
 # OS files
 Thumbs.db 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "line-notes-sync",
   "name": "LINE Notes Sync",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "minAppVersion": "1.3.0",
   "description": "Sync messages from LINE to your notes.",
   "author": "onikun94",

--- a/packages/cloudflare-worker/src/worker.ts
+++ b/packages/cloudflare-worker/src/worker.ts
@@ -18,6 +18,7 @@ interface LineMessage {
   userId: string;
   text: string;
   vaultId: string;
+  synced?: boolean;
 }
 
 const app = new Hono<{ Bindings: Bindings }>();

--- a/packages/obsidian-plugin/.env.sample
+++ b/packages/obsidian-plugin/.env.sample
@@ -1,0 +1,3 @@
+# このファイルをコピーして.env.local を作成してください
+# ローカル開発環境
+# OBSIDIAN_LINE_API_URL=http://localhost:8787

--- a/packages/obsidian-plugin/esbuild.config.mjs
+++ b/packages/obsidian-plugin/esbuild.config.mjs
@@ -3,7 +3,17 @@ import process from "process";
 import builtins from "builtin-modules";
 import dotenv from 'dotenv';
 
-dotenv.config();
+const isProd = process.env.NODE_ENV === 'production';
+const isCI = process.env.CI === 'true';
+
+if (!isCI && !process.env.OBSIDIAN_LINE_API_URL) {
+  dotenv.config({ path: '.env.local' });
+}
+
+if (isProd && !process.env.OBSIDIAN_LINE_API_URL) {
+  console.warn('\x1b[33m%s\x1b[0m', `警告: 本番環境でOBSIDIAN_LINE_API_URLが設定されていません。
+GitHub Actionsの環境変数でOBSIDIAN_LINE_API_URLを設定してください。`);
+}
 
 const banner =
 `/*
@@ -63,4 +73,4 @@ if (prod) {
   process.exit(0);
 } else {
   await context.watch();
-} 
+}

--- a/packages/obsidian-plugin/src/constants.ts
+++ b/packages/obsidian-plugin/src/constants.ts
@@ -4,4 +4,5 @@ export const API_ENDPOINTS = {
   BASE_URL,
   MESSAGES: (vaultId: string): string => `${BASE_URL}/messages/${vaultId}`,
   MAPPING: `${BASE_URL}/mapping`,
+  UPDATE_SYNC_STATUS: `${BASE_URL}/messages/update-sync-status`,
 } as const; 

--- a/packages/obsidian-plugin/src/constants.ts
+++ b/packages/obsidian-plugin/src/constants.ts
@@ -1,4 +1,11 @@
-const BASE_URL = process.env.OBSIDIAN_LINE_API_URL
+const isLocalMode = process.env.NODE_ENV === 'local';
+
+const BASE_URL = process.env.OBSIDIAN_LINE_API_URL || 
+  (isLocalMode ? 'http://localhost:8787' : '');
+
+if (!BASE_URL) {
+  console.error('警告: OBSIDIAN_LINE_API_URLが設定されていません。APIとの通信ができません。');
+}
 
 export const API_ENDPOINTS = {
   BASE_URL,

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -20,6 +20,7 @@ interface LineMessage {
   userId: string;
   text: string;
   vaultId: string;
+  synced?: boolean;
 }
 
 export default class LinePlugin extends Plugin {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,6 @@ compatibility_date = "2024-09-23"
 # Node.js互換性フラグ
 compatibility_flags = ["nodejs_compat"]
 
-# KVストアのバインディング
 kv_namespaces = [
   { binding = "LINE_MESSAGES", id = "27d7dbccef1b42fc9e0c4fde1e9fe005" },
   { binding = "LINE_USER_MAPPINGS", id = "65f9de2e1c514dd3aae66f79f6ceb936" }
@@ -15,10 +14,13 @@ kv_namespaces = [
 [observability.logs]
 enabled = true
 
-
 [build]
 command = "pnpm --filter cloudflare-worker build"
 cwd = "."
 
-[vars]
-# 公開しても問題ない環境変数はここに記述できます 
+[env.development]
+name = "line-to-obsidian-dev"
+kv_namespaces = [
+  { binding = "LINE_MESSAGES", id = "d874dd512f06435da9003ca674fdea1e", preview_id = "d874dd512f06435da9003ca674fdea1e" },
+  { binding = "LINE_USER_MAPPINGS", id = "7b0098cda3b145c6bb9675e7e872cc29", preview_id = "7b0098cda3b145c6bb9675e7e872cc29" }
+]


### PR DESCRIPTION
同期済みフラグを追加して、既にObsidianに同期されたメッセージを追跡します。
これにより、削除されたノートが将来の同期操作で再作成されるのを防ぎながら、
新しいメッセージは適切に同期できるようになります。
