### PR TITLE
feat: enable promotion codes on Stripe checkout

### DIFF
--- a/packages/cloudflare-worker/src/stripe/client.ts
+++ b/packages/cloudflare-worker/src/stripe/client.ts
@@ -19,6 +19,7 @@ export async function createCheckoutSession(params: {
     'success_url': params.successUrl,
     'cancel_url': params.cancelUrl,
     'metadata[lineUserId]': params.lineUserId,
+    'allow_promotion_codes': 'true',
   });
 
   const response = await fetch(`${STRIPE_API_BASE}/checkout/sessions`, {


### PR DESCRIPTION
## Summary
- Enable promotion code input on Stripe checkout page for coupon-based discounts

## Changes
- Add `allow_promotion_codes: true` to Stripe checkout session creation in `packages/cloudflare-worker/src/stripe/client.ts`