### PR TITLE
fix: E2EE公開鍵の再登録漏れを修正

### DIFF
--- a/packages/obsidian-plugin/src/crypto/keyManager.ts
+++ b/packages/obsidian-plugin/src/crypto/keyManager.ts
@@ -276,5 +276,13 @@ export class KeyManager {
     }
 
     await this.registerPublicKey(keys);
+
+    const data = await this.plugin.loadData();
+    if (data) {
+      delete data.pendingKeyRegistration;
+      delete data.registrationFailureCount;
+      delete data.lastRegistrationAttempt;
+      await this.plugin.saveData(data);
+    }
   }
 }

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -821,11 +821,35 @@ export default class LinePlugin extends Plugin {
     }
   }
 
+  private async registerCurrentPublicKey(): Promise<void> {
+    try {
+      await this.keyManager.initialize();
+    } catch (error) {
+      const keys = await this.keyManager.loadKeys();
+      if (!keys) {
+        throw error;
+      }
+
+      if (process.env.NODE_ENV === 'development') {
+        console.warn('Key initialization reported an error, retrying public key registration with existing keys:', error);
+      }
+    }
+
+    await this.keyManager.forceRegisterPublicKey();
+  }
+
   async registerMapping() {
-    if (!this.settings.lineUserId || !this.settings.vaultId) {
+    const lineUserId = this.settings.lineUserId.trim();
+    const vaultId = this.settings.vaultId.trim();
+
+    if (!lineUserId || !vaultId) {
       new Notice('LINE UserIDとVault IDの両方を設定してください。');
       return;
     }
+
+    this.settings.lineUserId = lineUserId;
+    this.settings.vaultId = vaultId;
+    await this.saveSettings();
 
     try {
       const response = await requestUrl({
@@ -835,8 +859,8 @@ export default class LinePlugin extends Plugin {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          userId: this.settings.lineUserId,
-          vaultId: this.settings.vaultId,
+          userId: lineUserId,
+          vaultId: vaultId,
         }),
       });
 
@@ -845,14 +869,16 @@ export default class LinePlugin extends Plugin {
       }
 
       try {
-        await this.keyManager.initialize();
+        await this.registerCurrentPublicKey();
       } catch (keyError) {
         if (process.env.NODE_ENV === 'development') {
-          console.error('Failed to initialize keys after mapping:', keyError);
+          console.error('Failed to register public key after mapping:', keyError);
         }
+        new Notice(`マッピングは登録されましたが、E2EE公開鍵の登録に失敗しました: ${keyError instanceof Error ? keyError.message : 'Unknown error'}`);
+        return;
       }
 
-      new Notice('LINE UserIDとVault IDのマッピングを登録しました。');
+      new Notice('LINE UserIDとVault IDのマッピングとE2EE公開鍵を登録しました。');
     } catch (error) {
       new Notice(`マッピングの登録に失敗しました: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
@@ -1286,12 +1312,16 @@ class LineSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('Register mapping')
-      .setDesc('LINE UserIDとVault IDのマッピングを登録します')
+      .setDesc('LINE UserIDとVault IDのマッピングとE2EE公開鍵を登録します。メッセージを読み込めない場合もこの操作で接続を修復できます')
       .addButton(button => button
         .setButtonText('Register')
         .onClick(async () => {
           await this.plugin.registerMapping();
         }));
+
+    new Setting(containerEl)
+      .setHeading()
+      .setName('詳細設定');
 
     new Setting(containerEl)
       .setName('Reset mapping')

--- a/packages/obsidian-plugin/tests/unit/main.test.ts
+++ b/packages/obsidian-plugin/tests/unit/main.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Notice, requestUrl } from 'obsidian';
 import LinePlugin from '../../src/main';
 
 // Obsidian APIのモック
@@ -294,6 +295,93 @@ describe('LinePlugin', () => {
       // resetMappingのロジックをテスト
       const shouldProceed = !!(plugin.settings.lineUserId && plugin.settings.vaultId);
       expect(shouldProceed).toBe(true);
+    });
+  });
+
+  describe('マッピング登録', () => {
+    it('マッピング登録後に既存のE2EE公開鍵を強制再登録する', async () => {
+      const initialize = vi.fn().mockResolvedValue(undefined);
+      const loadKeys = vi.fn().mockResolvedValue({ keyId: 'key-1' });
+      const forceRegisterPublicKey = vi.fn().mockResolvedValue(undefined);
+
+      plugin.keyManager = {
+        initialize,
+        loadKeys,
+        forceRegisterPublicKey
+      } as any;
+
+      plugin.settings = {
+        noteFolderPath: 'LINE',
+        vaultId: ' test-vault ',
+        lineUserId: ' test-user ',
+        autoSync: false,
+        syncInterval: 1,
+        syncOnStartup: false,
+        organizeByDate: false,
+        fileNameTemplate: '{date}-{messageId}',
+        e2eeEnabled: true,
+        groupMessagesByDate: false,
+        groupedMessageTemplate: '{time}: {text}',
+        groupedFrontmatterTemplate: 'source: LINE\ndate: {date}',
+        groupedFileNameTemplate: '{date}',
+        syncImages: true,
+        imageFolderPath: 'LINE/images',
+        imageFileNameTemplate: '{date}-{messageId}'
+      };
+
+      vi.mocked(requestUrl).mockResolvedValue({ status: 200 } as any);
+
+      await plugin.registerMapping();
+
+      expect(requestUrl).toHaveBeenCalledWith(expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          userId: 'test-user',
+          vaultId: 'test-vault',
+        }),
+      }));
+      expect(initialize).toHaveBeenCalled();
+      expect(forceRegisterPublicKey).toHaveBeenCalled();
+      expect(Notice).toHaveBeenCalledWith('LINE UserIDとVault IDのマッピングとE2EE公開鍵を登録しました。');
+    });
+
+    it('公開鍵登録に失敗した場合はマッピング成功だけを成功扱いしない', async () => {
+      const initialize = vi.fn().mockResolvedValue(undefined);
+      const loadKeys = vi.fn().mockResolvedValue({ keyId: 'key-1' });
+      const forceRegisterPublicKey = vi.fn().mockRejectedValue(new Error('key registration failed'));
+
+      plugin.keyManager = {
+        initialize,
+        loadKeys,
+        forceRegisterPublicKey
+      } as any;
+
+      plugin.settings = {
+        noteFolderPath: 'LINE',
+        vaultId: 'test-vault',
+        lineUserId: 'test-user',
+        autoSync: false,
+        syncInterval: 1,
+        syncOnStartup: false,
+        organizeByDate: false,
+        fileNameTemplate: '{date}-{messageId}',
+        e2eeEnabled: true,
+        groupMessagesByDate: false,
+        groupedMessageTemplate: '{time}: {text}',
+        groupedFrontmatterTemplate: 'source: LINE\ndate: {date}',
+        groupedFileNameTemplate: '{date}',
+        syncImages: true,
+        imageFolderPath: 'LINE/images',
+        imageFileNameTemplate: '{date}-{messageId}'
+      };
+
+      vi.mocked(requestUrl).mockResolvedValue({ status: 200 } as any);
+
+      await plugin.registerMapping();
+
+      expect(forceRegisterPublicKey).toHaveBeenCalled();
+      expect(Notice).toHaveBeenCalledWith('マッピングは登録されましたが、E2EE公開鍵の登録に失敗しました: key registration failed');
+      expect(Notice).not.toHaveBeenCalledWith('LINE UserIDとVault IDのマッピングとE2EE公開鍵を登録しました。');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Register mapping で既存の E2EE 公開鍵を強制再登録し、ローカル鍵と Worker KV の不整合を復旧できるようにしました
- 公開鍵登録に失敗した場合は成功扱いせず、ユーザーへ失敗を通知します
- 公開鍵再登録の回帰テストを追加しました

## Changes
- `registerMapping()` で LINE UserID / Vault ID を trim して保存し、mapping 登録後に `forceRegisterPublicKey()` を呼ぶよう変更
- `forceRegisterPublicKey()` 成功時に pending registration metadata をクリア
- 設定画面は Register mapping に公開鍵再登録の役割を含め、Reset mapping を詳細設定へ分離