### PR TITLE
fix: restore wrangler build path for line-to-obsidian Worker

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=*wrangler*

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,52 @@
+name = "line-to-obsidian"
+main = "packages/cloudflare-worker/src/worker.ts"
+compatibility_date = "2024-09-23"
+
+# Node.js互換性フラグ
+compatibility_flags = ["nodejs_compat"]
+
+kv_namespaces = [
+  { binding = "LINE_MESSAGES", id = "27d7dbccef1b42fc9e0c4fde1e9fe005" },
+  { binding = "LINE_USER_MAPPINGS", id = "65f9de2e1c514dd3aae66f79f6ceb936" },
+  { binding = "LINE_PUBLIC_KEYS", id = "7d09ceac83cd47d28ebab563201208bb" },
+  { binding = "LINE_SUBSCRIPTIONS", id = "b006bae6a30647758ae0d03501181dec" }
+]
+
+# All sensitive values are managed via `wrangler secret put`:
+# - STRIPE_SECRET_KEY
+# - STRIPE_WEBHOOK_SECRET
+# - STRIPE_PUBLISHABLE_KEY
+# - STRIPE_PRICE_ID
+# - PAYMENT_PAGE_URL
+
+# R2 bucket for image storage
+[[r2_buckets]]
+binding = "LINE_IMAGES"
+bucket_name = "line-images"
+
+# wrangler.toml (wrangler v3.88.0^)
+[observability.logs]
+enabled = true
+
+[build]
+command = "pnpm --filter cloudflare-worker build"
+cwd = "."
+
+[env.development]
+name = "line-to-obsidian-dev"
+kv_namespaces = [
+  { binding = "LINE_MESSAGES", id = "d874dd512f06435da9003ca674fdea1e", preview_id = "d874dd512f06435da9003ca674fdea1e" },
+  { binding = "LINE_USER_MAPPINGS", id = "7b0098cda3b145c6bb9675e7e872cc29", preview_id = "7b0098cda3b145c6bb9675e7e872cc29" },
+  { binding = "LINE_PUBLIC_KEYS", id = "6e05ea177e1a47abbed6997d6c53bd64", preview_id = "6e05ea177e1a47abbed6997d6c53bd64" },
+  { binding = "LINE_SUBSCRIPTIONS", id = "a4fe8bdc80a2450ca8ff07084bf3285d", preview_id = "a4fe8bdc80a2450ca8ff07084bf3285d" }
+]
+
+# Development environment secrets are set via:
+# wrangler secret put STRIPE_PUBLISHABLE_KEY --env development
+# wrangler secret put STRIPE_PRICE_ID --env development
+# wrangler secret put PAYMENT_PAGE_URL --env development
+
+[[env.development.r2_buckets]]
+binding = "LINE_IMAGES"
+bucket_name = "line-images-dev"
+preview_bucket_name = "line-images-dev"


### PR DESCRIPTION
## Summary

Fix the Cloudflare Workers Git Integration build that has been failing since commit `ade44d5`.

## Background

Commit `ade44d5` ("fix: address Obsidian review warnings") removed:
- `wrangler` from root `package.json` devDependencies
- Root-level `wrangler.toml`

This broke the Cloudflare Workers Git Integration build (Deploy command: `npx wrangler deploy`) because:
1. `npx wrangler` from the repo root could not find wrangler (pnpm does not hoist by default)
2. wrangler 4.x refuses to operate from a workspace root without a wrangler.toml

## Changes

- **.npmrc**: Added `public-hoist-pattern[]=*wrangler*` to expose wrangler binary at root `node_modules/.bin/` without adding wrangler to root `package.json` (avoids Obsidian review tool's "duplicate devDep" warning)
- **wrangler.toml**: Restored at repo root with `main = "packages/cloudflare-worker/src/worker.ts"` so wrangler 4.x can deploy from the workspace root

## Verification

- `npx wrangler deploy --dry-run` succeeds locally
- All bindings (LINE_MESSAGES, LINE_USER_MAPPINGS, LINE_PUBLIC_KEYS, LINE_SUBSCRIPTIONS, LINE_IMAGES) recognized
- esbuild bundle: 103.5kb (gzip 28.14 KiB)

## Note

The Deploy command in Cloudflare dashboard should remain `npx wrangler deploy`. No dashboard changes required.